### PR TITLE
Fix injection crash for newer forge versions

### DIFF
--- a/src/main/java/com/replaymod/mixin/MixinMouseHelper.java
+++ b/src/main/java/com/replaymod/mixin/MixinMouseHelper.java
@@ -25,7 +25,7 @@ public abstract class MixinMouseHelper {
     }
 
     @Inject(method = "scrollCallback",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/entity/player/ClientPlayerEntity;isSpectator()Z"),
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isSpectator()Z"),
             locals = LocalCapture.CAPTURE_FAILHARD,
             cancellable = true)
     private void handleReplayModScroll(


### PR DESCRIPTION
The mod crashes on newer versions due to injecting `handleReplayModScroll` to `Lnet/minecraft/client/entity/player/ClientPlayerEntity;isSpectator()Z`. When comparing to the fabric version, it instead injects to the target `Lnet/minecraft/client/network/ClientPlayerEntity;isSpectator()Z`. After I changed this line and recompiled the mod, it launches fine on newer versions of forge.